### PR TITLE
Tweak macros

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -23,7 +23,7 @@ if (${CUDA_LIBRARY-NOTFOUND})
 else ()
     target_compile_definitions(wrapper_clp
             PUBLIC
-            -DCUPDLP_CPU
+            -DCUPDLP_CPU=1
     )
     target_link_libraries(onlinelp PUBLIC cupdlp ${CUDA_LIBRARY} m)
 endif ()

--- a/cupdlp/CMakeLists.txt
+++ b/cupdlp/CMakeLists.txt
@@ -15,14 +15,14 @@ add_library(cupdlp SHARED
 target_compile_definitions(cupdlp
         PUBLIC
         # If the debug configuration pass the DEBUG define to the compiler
-        $<$<CONFIG:Debug>:CUPDLP_DEBUG>
+        $<$<CONFIG:Debug>:-DCUPDLP_DEBUG=1>
 )
 
 if (${CUDA_LIBRARY-NOTFOUND})
     message(NOTICE "- CPU version PDLP")
     target_compile_definitions(cupdlp
             PUBLIC
-            -DCUPDLP_CPU
+            -DCUPDLP_CPU=1
     )
     target_link_libraries(cupdlp m)
 else()

--- a/cupdlp/cuda/CMakeLists.txt
+++ b/cupdlp/cuda/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(cudalin PUBLIC "/usr/local/cuda/include")
 target_compile_definitions(cudalin
         PUBLIC
         # If the debug configuration pass the DEBUG define to the compiler
-        $<$<CONFIG:Debug>:CUPDLP_DEBUG>
+        $<$<CONFIG:Debug>:-DCUPDLP_DEBUG=1>
 )
 
 target_link_libraries(cudalin ${CUDA_LIBRARY} m)

--- a/cupdlp/cuda/cupdlp_cuda_kernels.cuh
+++ b/cupdlp/cuda/cupdlp_cuda_kernels.cuh
@@ -58,7 +58,7 @@ typedef double cupdlp_float;
 #define CUPDLP_INIT_VEC(var, size)                                             \
   {                                                                            \
     cusparseStatus_t status =                                                  \
-        cudaMalloc((void **)&var, (size) * sizeof(typeof(*var)));              \
+        cudaMalloc((void **)&var, (size) * sizeof(__typeof__(*var)));          \
     if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
       printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
              cusparseGetErrorString(status), status);                          \
@@ -68,13 +68,13 @@ typedef double cupdlp_float;
 #define CUPDLP_INIT_ZERO_VEC(var, size)                                        \
   {                                                                            \
     cusparseStatus_t status =                                                  \
-        cudaMalloc((void **)&var, (size) * sizeof(typeof(*var)));              \
+        cudaMalloc((void **)&var, (size) * sizeof(__typeof__(*var)));          \
     if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
       printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
              cusparseGetErrorString(status), status);                          \
       goto exit_cleanup;                                                       \
     }                                                                          \
-    status = cudaMemset(var, 0, (size) * sizeof(typeof(*var)));                \
+    status = cudaMemset(var, 0, (size) * sizeof(__typeof__(*var)));            \
     if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
       printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
              cusparseGetErrorString(status), status);                          \

--- a/cupdlp/cuda/cupdlp_cuda_kernels.cuh
+++ b/cupdlp/cuda/cupdlp_cuda_kernels.cuh
@@ -57,27 +57,27 @@ typedef double cupdlp_float;
 
 #define CUPDLP_INIT_VEC(var, size)                                             \
   {                                                                            \
-    cusparseStatus_t status =                                                  \
+    cudaError_t status =                                                       \
         cudaMalloc((void **)&var, (size) * sizeof(__typeof__(*var)));          \
-    if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
-      printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
-             cusparseGetErrorString(status), status);                          \
+    if (status != cudaSuccess) {                                               \
+      printf("CUDA API failed at line %d with error: %s (%d)\n",               \
+             __LINE__, cudaGetErrorString(status), status);                    \
       goto exit_cleanup;                                                       \
     }                                                                          \
   }
 #define CUPDLP_INIT_ZERO_VEC(var, size)                                        \
   {                                                                            \
-    cusparseStatus_t status =                                                  \
+    cudaError_t status =                                                       \
         cudaMalloc((void **)&var, (size) * sizeof(__typeof__(*var)));          \
-    if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
-      printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
-             cusparseGetErrorString(status), status);                          \
+    if (status != cudaSuccess) {                                               \
+      printf("CUDA API failed at line %d with error: %s (%d)\n",               \
+             __LINE__, cudaGetErrorString(status), status);                    \
       goto exit_cleanup;                                                       \
     }                                                                          \
     status = cudaMemset(var, 0, (size) * sizeof(__typeof__(*var)));            \
-    if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
-      printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
-             cusparseGetErrorString(status), status);                          \
+    if (status != cudaSuccess) {                                               \
+      printf("CUDA API failed at line %d with error: %s (%d)\n",               \
+             __LINE__, cudaGetErrorString(status), status);                    \
       goto exit_cleanup;                                                       \
     }                                                                          \
   }

--- a/cupdlp/cupdlp_defs.h
+++ b/cupdlp/cupdlp_defs.h
@@ -1,6 +1,13 @@
 #ifndef CUPDLP_H_GUARD
 #define CUPDLP_H_GUARD
 
+#ifndef CUPDLP_CPU
+#define CUPDLP_CPU (0)
+#endif
+#ifndef CUPDLP_DEBUG
+#define CUPDLP_DEBUG (0)
+#endif
+
 #if !(CUPDLP_CPU)
 #include "cuda/cupdlp_cuda_kernels.cuh"
 #include "cuda/cupdlp_cudalinalg.cuh"

--- a/cupdlp/cupdlp_solver.c
+++ b/cupdlp/cupdlp_solver.c
@@ -754,7 +754,7 @@ cupdlp_retcode PDHG_Solve(CUPDLPwork *pdhg) {
 
   for (timers->nIter = 0; timers->nIter < settings->nIterLim; ++timers->nIter) {
     PDHG_Compute_SolvingTime(pdhg);
-#if CUPDLP_DUMP_ITERATES_STATS & CUPDLP_DEBUG
+#if CUPDLP_DUMP_ITERATES_STATS && CUPDLP_DEBUG
     PDHG_Dump_Stats(pdhg);
 #endif
     int bool_checking = (timers->nIter < 10) ||

--- a/cupdlp/cupdlp_step.c
+++ b/cupdlp/cupdlp_step.c
@@ -17,7 +17,7 @@ void PDHG_primalGradientStep(CUPDLPwork *work, cupdlp_float dPrimalStepSize) {
   CUPDLPiterates *iterates = work->iterates;
   CUPDLPproblem *problem = work->problem;
 
-#if !(CUPDLP_CPU) & USE_KERNELS
+#if !(CUPDLP_CPU) && USE_KERNELS
   cupdlp_pgrad_cuda(iterates->xUpdate->data, iterates->x->data, problem->cost,
                     iterates->aty->data, dPrimalStepSize, problem->nCols);
 #else
@@ -44,7 +44,7 @@ void PDHG_dualGradientStep(CUPDLPwork *work, cupdlp_float dDualStepSize) {
   CUPDLPiterates *iterates = work->iterates;
   CUPDLPproblem *problem = work->problem;
 
-#if !(CUPDLP_CPU) & USE_KERNELS
+#if !(CUPDLP_CPU) && USE_KERNELS
   cupdlp_dgrad_cuda(iterates->yUpdate->data, iterates->y->data, problem->rhs,
                     iterates->ax->data, iterates->axUpdate->data, dDualStepSize,
                     problem->nRows);
@@ -208,7 +208,7 @@ cupdlp_retcode PDHG_Update_Iterate_Adaptive_Step_Size(CUPDLPwork *pdhg) {
     cupdlp_float dMovement = 0.0;
     cupdlp_float dInteraction = 0.0;
 
-#if !(CUPDLP_CPU) & USE_KERNELS
+#if !(CUPDLP_CPU) && USE_KERNELS
     cupdlp_compute_interaction_and_movement(pdhg, &dMovement, &dInteraction);
 #else
     cupdlp_float dX = 0.0;
@@ -228,7 +228,7 @@ cupdlp_retcode PDHG_Update_Iterate_Adaptive_Step_Size(CUPDLPwork *pdhg) {
                        problem->nCols, &dInteraction);
 #endif
 
-#if CUPDLP_DUMP_LINESEARCH_STATS & CUPDLP_DEBUG
+#if CUPDLP_DUMP_LINESEARCH_STATS && CUPDLP_DEBUG
     cupdlp_float dInteractiony = 0.0;
     //      Δy' (AΔx)
     cupdlp_diffDotDiff(pdhg, iterates->y->data, iterates->yUpdate->data,
@@ -256,7 +256,7 @@ cupdlp_retcode PDHG_Update_Iterate_Adaptive_Step_Size(CUPDLPwork *pdhg) {
         (1.0 + pow(stepsize->nStepSizeIter + 1.0, -PDHG_STEPSIZE_GROWTH_EXP)) *
         dStepSizeUpdate;
     dStepSizeUpdate = fmin(dFirstTerm, dSecondTerm);
-#if CUPDLP_DUMP_LINESEARCH_STATS & CUPDLP_DEBUG
+#if CUPDLP_DUMP_LINESEARCH_STATS && CUPDLP_DEBUG
     cupdlp_printf(" -- stepsize iteration %d: %f %f\n", stepIterThis,
                   dStepSizeUpdate, dStepSizeLimit);
 

--- a/cupdlp/glbopts.h
+++ b/cupdlp/glbopts.h
@@ -76,7 +76,7 @@ extern "C" {
 // #define CUPDLP_INIT_VEC(var, size)                                             \
 //   {                                                                            \
 //     cusparseStatus_t status =                                                  \
-//         cudaMalloc((void **)&var, (size) * sizeof(typeof(*var)));              \
+//         cudaMalloc((void **)&var, (size) * sizeof(__typeof__(*var)));          \
 //     if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
 //       printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
 //              cusparseGetErrorString(status), status);                          \
@@ -86,13 +86,13 @@ extern "C" {
 // #define CUPDLP_INIT_ZERO_VEC(var, size)                                        \
 //   {                                                                            \
 //     cusparseStatus_t status =                                                  \
-//         cudaMalloc((void **)&var, (size) * sizeof(typeof(*var)));              \
+//         cudaMalloc((void **)&var, (size) * sizeof(__typeof__(*var)));          \
 //     if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
 //       printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
 //              cusparseGetErrorString(status), status);                          \
 //       goto exit_cleanup;                                                       \
 //     }                                                                          \
-//     status = cudaMemset(var, 0, (size) * sizeof(typeof(*var)));                \
+//     status = cudaMemset(var, 0, (size) * sizeof(__typeof__(*var)));            \
 //     if (status != CUSPARSE_STATUS_SUCCESS) {                                   \
 //       printf("CUSPARSE API failed at line %d with error: %s (%d)\n", __LINE__, \
 //              cusparseGetErrorString(status), status);                          \
@@ -105,21 +105,21 @@ extern "C" {
 #else
 #define CUPDLP_COPY_VEC(dst, src, type, size) \
   memcpy(dst, src, sizeof(type) * (size))
-#define CUPDLP_INIT_VEC(var, size)                              \
-  {                                                             \
-    (var) = (typeof(var))malloc((size) * sizeof(typeof(*var))); \
-    if ((var) == cupdlp_NULL) {                                 \
-      retcode = RETCODE_FAILED;                                 \
-      goto exit_cleanup;                                        \
-    }                                                           \
+#define CUPDLP_INIT_VEC(var, size)                                      \
+  {                                                                     \
+    (var) = (__typeof__(var))malloc((size) * sizeof(__typeof__(*var))); \
+    if ((var) == cupdlp_NULL) {                                         \
+      retcode = RETCODE_FAILED;                                         \
+      goto exit_cleanup;                                                \
+    }                                                                   \
   }
-#define CUPDLP_INIT_ZERO_VEC(var, size)                      \
-  {                                                          \
-    (var) = (typeof(var))calloc(size, sizeof(typeof(*var))); \
-    if ((var) == cupdlp_NULL) {                              \
-      retcode = RETCODE_FAILED;                              \
-      goto exit_cleanup;                                     \
-    }                                                        \
+#define CUPDLP_INIT_ZERO_VEC(var, size)                              \
+  {                                                                  \
+    (var) = (__typeof__(var))calloc(size, sizeof(__typeof__(*var))); \
+    if ((var) == cupdlp_NULL) {                                      \
+      retcode = RETCODE_FAILED;                                      \
+      goto exit_cleanup;                                             \
+    }                                                                \
   }
 #define CUPDLP_FREE_VEC(x) \
   {                        \
@@ -141,21 +141,21 @@ extern "C" {
 #define cupdlp_zero(var, type, size) memset(var, 0, sizeof(type) * (size))
 #define cupdlp_copy(dst, src, type, size) \
   memcpy(dst, src, sizeof(type) * (size))
-#define CUPDLP_INIT(var, size)                                  \
-  {                                                             \
-    (var) = (typeof(var))malloc((size) * sizeof(typeof(*var))); \
-    if ((var) == cupdlp_NULL) {                                 \
-      retcode = RETCODE_FAILED;                                 \
-      goto exit_cleanup;                                        \
-    }                                                           \
+#define CUPDLP_INIT(var, size)                                          \
+  {                                                                     \
+    (var) = (__typeof__(var))malloc((size) * sizeof(__typeof__(*var))); \
+    if ((var) == cupdlp_NULL) {                                         \
+      retcode = RETCODE_FAILED;                                         \
+      goto exit_cleanup;                                                \
+    }                                                                   \
   }
-#define CUPDLP_INIT_ZERO(var, size)                          \
-  {                                                          \
-    (var) = (typeof(var))calloc(size, sizeof(typeof(*var))); \
-    if ((var) == cupdlp_NULL) {                              \
-      retcode = RETCODE_FAILED;                              \
-      goto exit_cleanup;                                     \
-    }                                                        \
+#define CUPDLP_INIT_ZERO(var, size)                                  \
+  {                                                                  \
+    (var) = (__typeof__(var))calloc(size, sizeof(__typeof__(*var))); \
+    if ((var) == cupdlp_NULL) {                                      \
+      retcode = RETCODE_FAILED;                                      \
+      goto exit_cleanup;                                             \
+    }                                                                \
   }
 #define CUPDLP_FREE(var) cupdlp_free(var)
 #define CUPDLP_CALL(func)       \

--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -12,7 +12,7 @@ if (${CUDA_LIBRARY-NOTFOUND})
     message(NOTICE "- CPU version PDLP")
     target_compile_definitions(wrapper_lp
             PUBLIC
-            -DCUPDLP_CPU
+            -DCUPDLP_CPU=1
     )
 endif()
 
@@ -39,7 +39,7 @@ if (${CUDA_LIBRARY-NOTFOUND})
     message(NOTICE "- CPU version PDLP")
     target_compile_definitions(wrapper_highs
             PUBLIC
-            -DCUPDLP_CPU
+            -DCUPDLP_CPU=1
     )
 endif()
 

--- a/interface/wrapper_clp.cpp
+++ b/interface/wrapper_clp.cpp
@@ -118,7 +118,7 @@ extern "C" int formulateLP(void *model, double **cost, int *nCols, int *nRows,
   // }
   // cupdlp_printf("------------------------------------------------\n");
 
-  CUPDLP_INIT(is_eq, nRows_clp);
+  CUPDLP_CPP_INIT(is_eq, bool, nRows_clp);
 
   // recalculate nRows and nnz for Ax - z = 0
   for (int i = 0; i < nRows_clp; i++) {
@@ -136,13 +136,13 @@ extern "C" int formulateLP(void *model, double **cost, int *nCols, int *nRows,
   }
 
   // allocate memory
-  CUPDLP_INIT(*cost, *nCols);
-  CUPDLP_INIT(*lower, *nCols);
-  CUPDLP_INIT(*upper, *nCols);
-  CUPDLP_INIT(*csc_beg, *nCols + 1);
-  CUPDLP_INIT(*csc_idx, *nnz);
-  CUPDLP_INIT(*csc_val, *nnz);
-  CUPDLP_INIT(*rhs, *nRows);
+  CUPDLP_CPP_INIT(*cost, double, *nCols);
+  CUPDLP_CPP_INIT(*lower, double, *nCols);
+  CUPDLP_CPP_INIT(*upper, double, *nCols);
+  CUPDLP_CPP_INIT(*csc_beg, int, *nCols + 1);
+  CUPDLP_CPP_INIT(*csc_idx, int, *nnz);
+  CUPDLP_CPP_INIT(*csc_val, double, *nnz);
+  CUPDLP_CPP_INIT(*rhs, double, *nRows);
 
   // formulate LP matrix
   for (int i = 0; i < nCols_clp + 1; i++) (*csc_beg)[i] = A_csc_beg[i];
@@ -267,8 +267,8 @@ extern "C" int formulateLP_new(void *model, double **cost, int *nCols,
   const double *A_csc_val = ((const ClpModel *)model)->matrix()->getElements();
   int has_lower, has_upper;
 
-  CUPDLP_INIT(constraint_type_clp, nRows_clp);
-  CUPDLP_INIT(*constraint_new_idx, *nRows);
+  CUPDLP_CPP_INIT(constraint_type_clp, constraint_type, nRows_clp);
+  CUPDLP_CPP_INIT(*constraint_new_idx, int, *nRows);
 
   // recalculate nRows and nnz for Ax - z = 0
   for (int i = 0; i < nRows_clp; i++) {
@@ -302,13 +302,13 @@ extern "C" int formulateLP_new(void *model, double **cost, int *nCols,
   }
 
   // allocate memory
-  CUPDLP_INIT(*cost, *nCols);
-  CUPDLP_INIT(*lower, *nCols);
-  CUPDLP_INIT(*upper, *nCols);
-  CUPDLP_INIT(*csc_beg, *nCols + 1);
-  CUPDLP_INIT(*csc_idx, *nnz);
-  CUPDLP_INIT(*csc_val, *nnz);
-  CUPDLP_INIT(*rhs, *nRows);
+  CUPDLP_CPP_INIT(*cost, double, *nCols);
+  CUPDLP_CPP_INIT(*lower, double, *nCols);
+  CUPDLP_CPP_INIT(*upper, double, *nCols);
+  CUPDLP_CPP_INIT(*csc_beg, int, *nCols + 1);
+  CUPDLP_CPP_INIT(*csc_idx, int, *nnz);
+  CUPDLP_CPP_INIT(*csc_val, double, *nnz);
+  CUPDLP_CPP_INIT(*rhs, double, *nRows);
 
   // cost, lower, upper
   for (int i = 0; i < nCols_clp; i++) {

--- a/interface/wrapper_clp.h
+++ b/interface/wrapper_clp.h
@@ -9,13 +9,13 @@
 extern "C" {
 #endif
 
-#define CUPDLP_INIT(var, size)                                  \
-  {                                                             \
-    (var) = (typeof(var))malloc((size) * sizeof(typeof(*var))); \
-    if ((var) == NULL) {                                        \
-      retcode = 1;                                              \
-      goto exit_cleanup;                                        \
-    }                                                           \
+#define CUPDLP_CPP_INIT(var, type, size)                                \
+  {                                                                     \
+    (var) = (type *)malloc((size) * sizeof(type));                      \
+    if ((var) == NULL) {                                                \
+      retcode = 1;                                                      \
+      goto exit_cleanup;                                                \
+    }                                                                   \
   }
 
 typedef enum CONSTRAINT_TYPE { EQ = 0, LEQ, GEQ, BOUND } constraint_type;

--- a/interface/wrapper_highs.cpp
+++ b/interface/wrapper_highs.cpp
@@ -338,8 +338,8 @@ extern "C" int formulateLP_highs(void *model, double **cost, int *nCols,
   const double *A_csc_val = lp.a_matrix_.value_.data();
   int has_lower, has_upper;
 
-  CUPDLP_INIT(*constraint_type, nRows_highs);
-  CUPDLP_INIT(*constraint_new_idx, *nRows);
+  CUPDLP_CPP_INIT(*constraint_type, int, nRows_highs);
+  CUPDLP_CPP_INIT(*constraint_new_idx, int, *nRows);
 
   // recalculate nRows and nnz for Ax - z = 0
   for (int i = 0; i < nRows_highs; i++) {
@@ -374,13 +374,13 @@ extern "C" int formulateLP_highs(void *model, double **cost, int *nCols,
   }
 
   // allocate memory
-  CUPDLP_INIT(*cost, *nCols);
-  CUPDLP_INIT(*lower, *nCols);
-  CUPDLP_INIT(*upper, *nCols);
-  CUPDLP_INIT(*csc_beg, *nCols + 1);
-  CUPDLP_INIT(*csc_idx, *nnz);
-  CUPDLP_INIT(*csc_val, *nnz);
-  CUPDLP_INIT(*rhs, *nRows);
+  CUPDLP_CPP_INIT(*cost, double, *nCols);
+  CUPDLP_CPP_INIT(*lower, double, *nCols);
+  CUPDLP_CPP_INIT(*upper, double, *nCols);
+  CUPDLP_CPP_INIT(*csc_beg, int, *nCols + 1);
+  CUPDLP_CPP_INIT(*csc_idx, int, *nnz);
+  CUPDLP_CPP_INIT(*csc_val, double, *nnz);
+  CUPDLP_CPP_INIT(*rhs, double, *nRows);
 
   // cost, lower, upper
   for (int i = 0; i < nCols_highs; i++) {

--- a/interface/wrapper_highs.h
+++ b/interface/wrapper_highs.h
@@ -9,13 +9,13 @@
 extern "C" {
 #endif
 
-#define CUPDLP_INIT(var, size)                                  \
-  {                                                             \
-    (var) = (typeof(var))malloc((size) * sizeof(typeof(*var))); \
-    if ((var) == NULL) {                                        \
-      retcode = 1;                                              \
-      goto exit_cleanup;                                        \
-    }                                                           \
+#define CUPDLP_CPP_INIT(var, type, size)                                \
+  {                                                                     \
+    (var) = (type *)malloc((size) * sizeof(type));                      \
+    if ((var) == NULL) {                                                \
+      retcode = 1;                                                      \
+      goto exit_cleanup;                                                \
+    }                                                                   \
   }
 
 typedef enum CONSTRAINT_TYPE { EQ = 0, LEQ, GEQ, BOUND } ConstraintType;


### PR DESCRIPTION
This deals with an issues also covered in #17, but I feel the changes here are simpler and more in line with the rest of the code.

Tested with MSVC 19.39.33523 for x64, windows 10.
For the change to __typeof__, see https://learn.microsoft.com/en-us/cpp/c-language/typeof-c?view=msvc-170 (the project is configured to use C99 through Cmake).
From what I can tell, it should also work with GCC (https://gcc.gnu.org/onlinedocs/gcc/Typeof.html) and Clang (https://clang.llvm.org/docs/UsersManual.html), but I have not tested this.