### PR TITLE
Fix for cusparse, cuda 12.4

### DIFF
--- a/cupdlp/cuda/cupdlp_cudalinalg.cuh
+++ b/cupdlp/cuda/cupdlp_cudalinalg.cuh
@@ -26,7 +26,7 @@ extern "C" cupdlp_int cuda_alloc_MVbuffer(
     cusparseHandle_t handle, cusparseSpMatDescr_t cuda_csc,
     cusparseDnVecDescr_t vecX, cusparseDnVecDescr_t vecAx,
     cusparseSpMatDescr_t cuda_csr, cusparseDnVecDescr_t vecY,
-    cusparseDnVecDescr_t vecATy, void **dBuffer);
+    cusparseDnVecDescr_t vecATy, void **dBuffer_csc_ATy, void **dBuffer_csr_Ax);
 
 extern "C" cupdlp_int cuda_csc_Ax(cusparseHandle_t handle,
                                   cusparseSpMatDescr_t cuda_csc,

--- a/cupdlp/cupdlp_defs.h
+++ b/cupdlp/cupdlp_defs.h
@@ -399,7 +399,8 @@ struct CUPDLP_WORK {
 #if !(CUPDLP_CPU)
   // CUDAmv *MV;
   cusparseHandle_t cusparsehandle;
-  void *dBuffer;
+  void *dBuffer_csc_ATy;
+  void *dBuffer_csr_Ax;
   // cusparseDnVecDescr_t vecbuffer;
   cublasHandle_t cublashandle;
 #endif

--- a/cupdlp/cupdlp_linalg.c
+++ b/cupdlp/cupdlp_linalg.c
@@ -387,19 +387,16 @@ void Ax_single_gpu(CUPDLPwork *w, cusparseDnVecDescr_t vecX,
 
   switch (w->problem->data->matrix_format) {
     case CSR_CSC:
-      // cuda_csc_Ax(w->cusparsehandle, w->problem->data->csc_matrix->cuda_csc,
-      //             vecX, vecAx, w->dBuffer, alpha, beta);
-
       cuda_csr_Ax(w->cusparsehandle, w->problem->data->csr_matrix->cuda_csr,
-                  vecX, vecAx, w->dBuffer, alpha, beta);
+                  vecX, vecAx, w->dBuffer_csr_Ax, alpha, beta);
       break;
     case CSC:
-      cuda_csc_Ax(w->cusparsehandle, w->problem->data->csc_matrix->cuda_csc,
-                  vecX, vecAx, w->dBuffer, alpha, beta);
+      cupdlp_printf("Error: Ax_single_gpu requires CSR matrix\n");
+      exit(1);
       break;
     case CSR:
       cuda_csr_Ax(w->cusparsehandle, w->problem->data->csr_matrix->cuda_csr,
-                  vecX, vecAx, w->dBuffer, alpha, beta);
+                  vecX, vecAx, w->dBuffer_csr_Ax, alpha, beta);
       break;
     default:
       cupdlp_printf("Error: Unknown matrix format in Ax_single_gpu\n");
@@ -422,18 +419,16 @@ void ATy_single_gpu(CUPDLPwork *w, cusparseDnVecDescr_t vecY,
 
   switch (w->problem->data->matrix_format) {
     case CSR_CSC:
-      // cuda_csr_ATy(w->cusparsehandle, w->problem->data->csr_matrix->cuda_csr,
-      //              vecY, vecATy, w->dBuffer, alpha, beta);
       cuda_csc_ATy(w->cusparsehandle, w->problem->data->csc_matrix->cuda_csc,
-                   vecY, vecATy, w->dBuffer, alpha, beta);
+                   vecY, vecATy, w->dBuffer_csc_ATy, alpha, beta);
       break;
     case CSC:
       cuda_csc_ATy(w->cusparsehandle, w->problem->data->csc_matrix->cuda_csc,
-                   vecY, vecATy, w->dBuffer, alpha, beta);
+                   vecY, vecATy, w->dBuffer_csc_ATy, alpha, beta);
       break;
     case CSR:
-      cuda_csr_ATy(w->cusparsehandle, w->problem->data->csr_matrix->cuda_csr,
-                   vecY, vecATy, w->dBuffer, alpha, beta);
+      cupdlp_printf("Error: ATy_single_gpu requires CSC matrix\n");
+      exit(1);
       break;
     default:
       printf("Error: Unknown matrix format in Ax_single_gpu\n");

--- a/cupdlp/cupdlp_utils.c
+++ b/cupdlp/cupdlp_utils.c
@@ -332,7 +332,8 @@ cupdlp_int PDHG_Clear(CUPDLPwork *w) {
     // }
     CHECK_CUBLAS(cublasDestroy(w->cublashandle))
     CHECK_CUSPARSE(cusparseDestroy(w->cusparsehandle))
-    CHECK_CUDA(cudaFree(w->dBuffer))
+    CHECK_CUDA(cudaFree(w->dBuffer_csc_ATy))
+    CHECK_CUDA(cudaFree(w->dBuffer_csr_Ax))
     if (w->buffer2) CUPDLP_FREE_VEC(w->buffer2);
     if (w->buffer3) CUPDLP_FREE_VEC(w->buffer3);
 #endif
@@ -1033,7 +1034,7 @@ cupdlp_retcode PDHG_Alloc(CUPDLPwork *w) {
       w->cusparsehandle, w->problem->data->csc_matrix->cuda_csc,
       w->iterates->x->cuda_vec, w->iterates->ax->cuda_vec,
       w->problem->data->csr_matrix->cuda_csr, w->iterates->y->cuda_vec,
-      w->iterates->aty->cuda_vec, &w->dBuffer);
+      w->iterates->aty->cuda_vec, &w->dBuffer_csc_ATy, &w->dBuffer_csr_Ax);
   w->timers->AllocMem_CopyMatToDeviceTime += getTimeStamp() - begin;
 #endif
 


### PR DESCRIPTION
I think this solves the problem with CUDA 12.4 (and probably later versions as well, but I've not verified that).

We have to give `cusparseSpMV` an external buffer, and it appears this buffer must not be "contaminated" between calls, and must be exclusive to a single matrix.
This PR creates a separate external buffer for each of the two matrices (different encodings of the same matrix) that we use (previously the same external buffer was used for both matrices).
This fixes the issues for me.

This is probably the issue ```The same external_buffer must be used for all cusparseSpMV calls. [CUSPARSE-1897]``` noted here:
https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cusparse-release-12-6