### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,23 @@ If you wish to use the Python interface, use the following steps:
 ```
 git submodule update --init --recursive
 ```
+If the submodule fails to initiate, then:
+```
+cd pycupdlp \
+rm -rf pybind11 \
+git clone https://github.com/pybind/pybind11.git
+cd ..
+```
 then build the target `pycupdlp`
 ```
+mkdir build
+cd build
+cmake -DBUILD_CUDA=ON \
+-DBUILD_PYTHON=ON \
+-DCMAKE_C_FLAGS_RELEASE="-O2 -DNDEBUG" \
+-DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG" \
+-DCMAKE_CUDA_FLAGS_RELEASE="-O2 -DNDEBUG" ..
+
 cmake --build . --target pycupdlp 
 ```
 


### PR DESCRIPTION
The build instructions for the Python interface are missing the requirement to turn the BUILD_PYTHON flag on.
Additionally, there appears to be a `403 unauthorized` message coming from the submodule, so if this is encountered, i've added some alternative instructions to put the pybind11 files where they should be.